### PR TITLE
Made the LLM calls more robust and added the ability to remove prefs

### DIFF
--- a/python/db/utils.py
+++ b/python/db/utils.py
@@ -286,3 +286,10 @@ class Prefs:
         DB.commit("DELETE FROM preferences WHERE key = ?", (pref,))
         DB.commit("INSERT INTO preferences (key,value) VALUES ( ? , ?)", (pref, value))
         self._preferences[pref] = value
+
+    def drop(self, pref=None):
+        if pref not in self._preferences:
+            raise KeyError(pref)
+        else:
+            DB.commit("DELETE FROM preferences WHERE key = ?", (pref,))
+            del self._preferences[pref]

--- a/python/golem.py
+++ b/python/golem.py
@@ -1,4 +1,4 @@
-from db import Prefs,DB
+from db import Prefs, DB
 from command import CommandManager
 from context import ContextManager
 from xalgo import ExecutiveManager
@@ -11,63 +11,97 @@ import subprocess
 
 def build_argparse():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--reset', action='store_true', help='Reset the system state to blank')
-    parser.add_argument('--root_directory', default=os.getcwd(), help='Path to the root of the install (default: current working directory)')
-    parser.add_argument('--test_command', default=None, help="Execute a command for testing purposes")
-    parser.add_argument('--enable_command', default=None, help="Add a command to the command manager.")
-    parser.add_argument('--disable_command', default=None, help="Remove a command from the command manager.")
-    parser.add_argument('--list_prefs', action='store_true', help="List all known preferences")
-    parser.add_argument('--set_pref_key', default=None,  help="The key to a preference to set")
-    parser.add_argument('--set_pref_val', default=None, help="The value of a preference to set")
-    parser.add_argument('--start', action='store_true', help="Start the robot prompt pump")
-    parser.add_argument('--stop', action='store_true', help="Start the robot prompt pump")
-    parser.add_argument('--prompt', default=None, help="Send the golem a prompt")
+    parser.add_argument(
+        "--reset", action="store_true", help="Reset the system state to blank"
+    )
+    parser.add_argument(
+        "--root_directory",
+        default=os.getcwd(),
+        help="Path to the root of the install (default: current working directory)",
+    )
+    parser.add_argument(
+        "--test_command", default=None, help="Execute a command for testing purposes"
+    )
+    parser.add_argument(
+        "--enable_command", default=None, help="Add a command to the command manager."
+    )
+    parser.add_argument(
+        "--disable_command",
+        default=None,
+        help="Remove a command from the command manager.",
+    )
+    parser.add_argument(
+        "--list_prefs", action="store_true", help="List all known preferences"
+    )
+    parser.add_argument(
+        "--set_pref_key", default=None, help="The key to a preference to set"
+    )
+    parser.add_argument(
+        "--set_pref_val", default=None, help="The value of a preference to set"
+    )
+    parser.add_argument(
+        "--drop_pref_key", default=None, help="The key of some preference to drop"
+    )
+    parser.add_argument(
+        "--start", action="store_true", help="Start the robot prompt pump"
+    )
+    parser.add_argument(
+        "--stop", action="store_true", help="Start the robot prompt pump"
+    )
+    parser.add_argument("--prompt", default=None, help="Send the golem a prompt")
     return parser.parse_args()
 
 
 def run_infinite_loop(llm_manager, executive_manager, context_manager, command_manager):
     ExecutiveManager.start()
-    DB.PREFS.reload() # Hot swapping prefs like a boss
+    DB.PREFS.reload()  # Hot swapping prefs like a boss
     while ExecutiveManager.is_running():
-        (prompt,context) = DB.pop_prompt()
-        (prompt,context,model) = executive_manager.prompt_in(prompt,context)
+        (prompt, context) = DB.pop_prompt()
+        (prompt, context, model) = executive_manager.prompt_in(prompt, context)
         if prompt == None:
-            (prompt,context,model) = executive_manager.no_prompt()
+            (prompt, context, model) = executive_manager.no_prompt()
         result = llm_manager.send_prompt(prompt, model, context)
-        (prompt,result,context) = executive_manager.response_out(prompt,result,context)
+        (prompt, result, context) = executive_manager.response_out(
+            prompt, result, context
+        )
         output = command_manager.run_command(result)
         llm_manager.flush_mood()
-        executive_manager.command_out(prompt,result,output,context)
+        executive_manager.command_out(prompt, result, output, context)
         DB.PREFS.reload()
 
 
-
-def main ():
+def main():
     args = build_argparse()
     DB.stat_db(args.root_directory)
     prefs = Prefs()
-    inout_path = prefs.get("inout directory",args.root_directory+"/inout")
+    inout_path = prefs.get("inout directory", args.root_directory + "/inout")
     os.makedirs(prefs.get("inout directory"), exist_ok=True)
     if args.reset:
         print("Resetting system")
         DB.reset()
-        DB.PREFS.set("root",args.root_directory)
-        inout = input ("Set your inout directory [inout]").strip()
+        DB.PREFS.set("root", args.root_directory)
+        inout = input("Set your inout directory [inout]").strip()
         if inout.strip() == "":
             inout = "inout"
-        DB.PREFS.set("inout directory",DB.PREFS.get("root") + "/" + inout)
-        subprocess.run(["rm","-rf",prefs.get("inout directory")])
+        DB.PREFS.set("inout directory", DB.PREFS.get("root") + "/" + inout)
+        subprocess.run(["rm", "-rf", prefs.get("inout directory")])
         os.makedirs(DB.PREFS.get("inout directory"), exist_ok=True)
 
     if args.list_prefs:
-        print (DB.PREFS._preferences)
+        print(DB.PREFS._preferences)
         exit(0)
-
 
     if args.set_pref_key:
         if not args.set_pref_val:
-            raise TypeError ("Missing --set_pref_val")
-        DB.PREFS.set(args.set_pref_key,args.set_pref_val)
+            raise TypeError("Missing --set_pref_val")
+        DB.PREFS.set(args.set_pref_key, args.set_pref_val)
+
+    if args.drop_pref_key:
+        try:
+            DB.PREFS.drop(args.drop_pref_key)
+        except KeyError:
+            print(f"No such preference key: {args.drop_pref_key}")
+            exit(0)
 
     command_manager = CommandManager()
     if args.enable_command is not None:
@@ -77,7 +111,7 @@ def main ():
     if args.disable_command is not None:
         command_manager.disable_command(args.disable_command)
         exit(0)
-    
+
     context_manager = ContextManager(command_manager)
     executive_manager = ExecutiveManager()
     llm_manager = LLMManager()
@@ -88,7 +122,9 @@ def main ():
         exit(0)
 
     if args.start:
-        run_infinite_loop(llm_manager, executive_manager, context_manager, command_manager)
+        run_infinite_loop(
+            llm_manager, executive_manager, context_manager, command_manager
+        )
         exit(0)
 
     if args.stop:
@@ -96,7 +132,10 @@ def main ():
         exit(0)
 
     if args.prompt is not None:
-        DB.queue_prompt(f"The user has provided a prompt.  Set a goal to help the user with their task.  The user's prompt:\n{args.prompt}")
-    
+        DB.queue_prompt(
+            f"The user has provided a prompt.  Set a goal to help the user with their task.  The user's prompt:\n{args.prompt}"
+        )
+
+
 if __name__ == "__main__":
-        main()
+    main()

--- a/python/llm/completions.py
+++ b/python/llm/completions.py
@@ -2,6 +2,7 @@ from db import DB
 import requests
 import json
 
+
 class Completions:
 
     API_ENDPOINT = "chat/completion endpoint"
@@ -15,34 +16,48 @@ class Completions:
 
     @staticmethod
     def send_prompt(prompt: str, model: str, context: str, chat_log: []) -> str:
-            
-        headers = {
-            "Content-Type": "application/json"
-        }
 
-        endpoint = DB.PREFS.get(Completions.API_ENDPOINT,"v1/chat/completions")
+        headers = {"Content-Type": "application/json"}
+
+        endpoint = DB.PREFS.get(Completions.API_ENDPOINT, "v1/chat/completions")
         url = DB.PREFS.get(Completions.URL)  # This will stall for input on first run
         full_url = url.strip("/") + "/" + endpoint
-        
+
         messages = [
             {"role": "system", "content": context},
         ]
-        for (role,msg) in chat_log:
+        for role, msg in chat_log:
             messages.append({"role": role, "content": msg})
         messages.append({"role": "user", "content": prompt})
 
         for message in messages:
             role = message["role"]
             content = message["content"]
-            print (f"{role}:\n{content}\n\n")
+            print(f"{role}:\n{content}\n\n")
         if model == None:
-            model = DB.PREFS.get(Completions.DEFAULT_MODEL,Completions.DEFAULT_SLOW)
+            model = DB.PREFS.get(Completions.DEFAULT_MODEL, Completions.DEFAULT_SLOW)
         payload = {
             "model": model,
             "messages": messages,
             "temperature": 0.3,
             "max_tokens": -1,  # Keep unlimited for direct requests
-            "stream": False
+            "stream": False,
         }
-        response = requests.post(full_url, headers=headers, data=json.dumps(payload), timeout=3000)
-        return response.json()["choices"][0]["message"]["content"]
+        try:
+            response = requests.post(
+                full_url, headers=headers, data=json.dumps(payload), timeout=3000
+            )
+            response.raise_for_status
+        except Timeout:
+            print("Request timed out.")
+        except requests.exceptions.HTTPError as e:
+            print(f"HTTP error occurred: {e.response.status_code} - {e.response.text}")
+        except requests.exceptions.ConnectionError:
+            print("Connection error occurred.")
+        except RequestException as e:
+            print(f"An error occurred: {e}")
+
+        try:
+            return response.json()["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError, ValueError):
+            return ""


### PR DESCRIPTION
Added try blocks around the request to the LLM and the response.
If, it can't get a reasonable answer, it now just returns an empty string and continues. I should double check that this is acts like a pause and doesn't start adding a string of weird "no-llm" markers to the state.

Next is to continue cleaning that code to make it easier to change.

If this commit didn't get squashed before the push, I probably made a mistake.

added --drop_pref_key
it does what it says on the label and calls utils.drop It the preference is set, it drops it and updates the _preferences summary otherwise it returns a keyerror

fixed utils so it correctly raises KeyError