### PR TITLE
First part of the improved prompt viewer

### DIFF
--- a/python/db/utils.py
+++ b/python/db/utils.py
@@ -165,6 +165,7 @@ class DB:
         cur.execute("DROP TABLE IF EXISTS last_boiler")
         cur.execute("DROP TABLE IF EXISTS thoughts")
         cur.execute("DROP TABLE IF EXISTS preferences")
+        cur.execute("DROP TABLE IF EXISTS prompts")
         cur.execute(
             """
                     create table preferences (
@@ -258,6 +259,14 @@ class DB:
                     create table mood (
                     mid integer primary key,
                     mood integer not null
+                    )"""
+        )
+        cur.execute(
+            """
+                    create table prompts (
+                    pid integer primary key,
+                    timestamp text not null,
+                    prompt text
                     )"""
         )
         conn.commit()

--- a/python/golem.py
+++ b/python/golem.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import shutil
 import subprocess
+import yaml
 
 
 def build_argparse():
@@ -49,6 +50,16 @@ def build_argparse():
         "--stop", action="store_true", help="Start the robot prompt pump"
     )
     parser.add_argument("--prompt", default=None, help="Send the golem a prompt")
+    parser.add_argument(
+        "--export_prefs",
+        default=None,
+        help="Export the current preferences to file",
+    )
+    parser.add_argument(
+        "--import_prefs",
+        default=None,
+        help="Import preferences from file",
+    )
     return parser.parse_args()
 
 
@@ -88,7 +99,7 @@ def main():
         os.makedirs(DB.PREFS.get("inout directory"), exist_ok=True)
 
     if args.list_prefs:
-        for k,v in DB.PREFS._preferences.items():
+        for k, v in DB.PREFS._preferences.items():
             print(f"'{k}': '{v}'")
         exit(0)
 
@@ -102,6 +113,22 @@ def main():
             DB.PREFS.drop(args.drop_pref_key)
         except KeyError:
             print(f"No such preference key: {args.drop_pref_key}")
+            exit(0)
+
+    if args.export_prefs:
+        with open(args.export_prefs, "w") as f:
+            yaml.safe_dump(DB.PREFS._preferences, f)
+        exit(0)
+
+    if args.import_prefs:
+        try:
+            with open(args.import_prefs, "r") as f:
+                loaded_prefs = yaml.safe_load(f)
+                for k, v in loaded_prefs.items():
+                    DB.PREFS.set(k, v)
+            exit(0)
+        except Exception as e:
+            print(f"Error importing {args.import_prefs}:\n {e}")
             exit(0)
 
     command_manager = CommandManager()

--- a/python/llm/completions.py
+++ b/python/llm/completions.py
@@ -61,7 +61,10 @@ class Completions:
             role = msg["role"]
             content = msg["content"]
             print(f"{role}:\n{content}\n")
-
+        DB.commit(
+            "INSERT INTO prompts (timestamp, prompt) VALUES (?, ?)",
+            (DB.cdt(), json.dumps(payload)),
+        )
         try:
             response = requests.post(
                 full_url, headers=headers, data=json.dumps(payload), timeout=3000


### PR DESCRIPTION
added logging prompts to DB
This currently can't be turned off so it will take up a lot of disk space. Keep an eye on it and delete old records by hand for now.
TODO: Allow the user to vary how much gets logged
TODO: deal with log rotation

added ability to export and import preferences to yaml file
QOL feature to make it easier to get back to a working state if you need to --reset